### PR TITLE
feat: add appwrite push notification example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # push-notifications-appwrite
-https://appwrite.io/ -- self-hosted cloud messaging
+
+Minimal example for sending a push notification using a self-hosted [Appwrite](https://appwrite.io/) instance.
+
+## Prerequisites
+- Docker & Docker Compose
+- Node.js 18+
+
+## Start Appwrite
+```bash
+docker compose up -d
+```
+Open http://localhost to finish the initial setup.
+
+## Configure messaging
+1. Create a project in the Appwrite console.
+2. Add a Messaging provider (e.g. FCM or APNs) and configure the credentials.
+3. From your mobile app, register the device with the project and copy its **device ID**.
+4. Generate an API key with the `Messaging` scope.
+
+## Send a test notification
+Set the following environment variables:
+```bash
+export APPWRITE_ENDPOINT=http://localhost/v1
+export APPWRITE_PROJECT_ID=<your_project_id>
+export APPWRITE_API_KEY=<your_api_key>
+export APPWRITE_DEVICE_ID=<registered_device_id>
+```
+Install dependencies and send the notification:
+```bash
+npm install
+npm run send
+```
+The script in [`scripts/send-notification.js`](scripts/send-notification.js) will create a push message titled *"Hello from Appwrite"* for the target device.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  appwrite:
+    image: appwrite/appwrite:1.5
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    environment:
+      - _APP_ENV=production
+      - _APP_OPENSSL_KEY_V1=${APPWRITE_SECRET:-your-random-secret}
+      - _APP_DOMAIN=localhost
+      - _APP_DOMAIN_TARGET=localhost
+    volumes:
+      - appwrite-storage:/storage:rw
+      - appwrite-config:/config:rw
+
+volumes:
+  appwrite-storage:
+  appwrite-config:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "push-notifications-appwrite",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "push-notifications-appwrite",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-appwrite": "^17.2.0"
+      }
+    },
+    "node_modules/node-appwrite": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/node-appwrite/-/node-appwrite-17.2.0.tgz",
+      "integrity": "sha512-naYUsVZEdF6YKF/q/s0DBQkAHJj2RhEWwmcXrkbfAAPc3Bn+D3CCftBqyNWeo17JBCoYWqQEgT2Od9xOVQR26A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "node-fetch-native-with-agent": "1.7.2"
+      }
+    },
+    "node_modules/node-fetch-native-with-agent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-native-with-agent/-/node-fetch-native-with-agent-1.7.2.tgz",
+      "integrity": "sha512-5MaOOCuJEvcckoz7/tjdx1M6OusOY6Xc5f459IaruGStWnKzlI1qpNgaAwmn4LmFYcsSlj+jBMk84wmmRxfk5g==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "push-notifications-appwrite",
+  "version": "1.0.0",
+  "description": "https://appwrite.io/ -- self-hosted cloud messaging",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "send": "node scripts/send-notification.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "node-appwrite": "^17.2.0"
+  }
+}

--- a/scripts/send-notification.js
+++ b/scripts/send-notification.js
@@ -1,0 +1,33 @@
+import { Client, Messaging, ID } from 'node-appwrite';
+
+const endpoint = process.env.APPWRITE_ENDPOINT || 'http://localhost/v1';
+const project = process.env.APPWRITE_PROJECT_ID;
+const key = process.env.APPWRITE_API_KEY;
+const deviceId = process.env.APPWRITE_DEVICE_ID;
+
+if (!project || !key || !deviceId) {
+  console.error('Missing one of APPWRITE_PROJECT_ID, APPWRITE_API_KEY, or APPWRITE_DEVICE_ID env variables.');
+  process.exit(1);
+}
+
+if (process.env.DRY_RUN) {
+  console.log('DRY RUN: would send push notification.');
+  process.exit(0);
+}
+
+const client = new Client()
+  .setEndpoint(endpoint)
+  .setProject(project)
+  .setKey(key);
+
+const messaging = new Messaging(client);
+
+async function main() {
+  const res = await messaging.createPush(ID.unique(), 'Hello from Appwrite', 'Test push from Node', [], [], [deviceId]);
+  console.log('Sent message', res);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add docker-compose file to self-host Appwrite
- add Node script to send push notification
- document setup and run instructions

## Testing
- `DRY_RUN=1 APPWRITE_PROJECT_ID=proj APPWRITE_API_KEY=key APPWRITE_DEVICE_ID=device npm run send`